### PR TITLE
Add basic tests and UI styling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.springframework.boot' version '3.1.2'
     id 'io.spring.dependency-management' version '1.1.0'
     id 'java'
+    id 'jacoco'
 }
 
 group = 'com.youtube.ai'
@@ -24,4 +25,25 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
 }
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+    }
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                minimum = 0.6
+            }
+        }
+    }
+}
+
+check.dependsOn jacocoTestCoverageVerification

--- a/src/main/resources/static/styles.css
+++ b/src/main/resources/static/styles.css
@@ -1,0 +1,31 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 20px;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+table, th, td {
+    border: 1px solid #ccc;
+}
+
+th, td {
+    padding: 8px;
+    text-align: left;
+}
+
+th {
+    background-color: #f2f2f2;
+}
+
+form input, form button {
+    margin: 4px 0;
+    padding: 6px;
+}
+
+button {
+    padding: 6px 12px;
+}

--- a/src/main/resources/templates/form.html
+++ b/src/main/resources/templates/form.html
@@ -1,7 +1,11 @@
 
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
-<head><meta charset="UTF-8"><title>Yeni Görev</title></head>
+<head>
+    <meta charset="UTF-8">
+    <title>Yeni Görev</title>
+    <link rel="stylesheet" th:href="@{/styles.css}" />
+</head>
 <body>
 <h2>Yeni Zamanlanmış SH Görevi</h2>
 <form action="/jobs" method="post" th:object="${job}">

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -4,6 +4,7 @@
 <head>
     <title>SH Zamanlayıcı</title>
     <meta charset="UTF-8" />
+    <link rel="stylesheet" th:href="@{/styles.css}" />
 </head>
 <body>
 <h1 th:text="${message}">[Mesaj Yüklenemedi]</h1>

--- a/src/main/resources/templates/list.html
+++ b/src/main/resources/templates/list.html
@@ -1,11 +1,15 @@
 
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
-<head><meta charset="UTF-8"><title>Job List</title></head>
+<head>
+    <meta charset="UTF-8">
+    <title>Job List</title>
+    <link rel="stylesheet" th:href="@{/styles.css}" />
+</head>
 <body>
 <h2>Tanımlı Görevler</h2>
 <a href="/jobs/new">Yeni Görev</a>
-<table border="1">
+<table>
 <tr><th>Ad</th><th>Script</th><th>Cron</th><th>İşlem</th></tr>
 <tr th:each="job : ${jobs}">
     <td th:text="${job.name}">Ad</td>

--- a/src/test/java/com/youtube/ai/scheduler/JobControllerTest.java
+++ b/src/test/java/com/youtube/ai/scheduler/JobControllerTest.java
@@ -1,0 +1,55 @@
+package com.youtube.ai.scheduler;
+
+import com.youtube.ai.scheduler.model.Job;
+import com.youtube.ai.scheduler.repository.JobRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class JobControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    JobRepository repository;
+
+    @TempDir
+    Path tempDir;
+
+    private Job createJob() throws Exception {
+        Path script = tempDir.resolve("c.sh");
+        Files.write(script, List.of("#!/bin/bash", "echo controller"));
+        script.toFile().setExecutable(true);
+
+        Job job = new Job();
+        job.setName("controller");
+        job.setScriptPath(script.toString());
+        job.setCronExpression("* * * * *");
+        job.setActive(false);
+        return repository.save(job);
+    }
+
+    @Test
+    void listJobsPageWorks() throws Exception {
+        createJob();
+        mockMvc.perform(get("/jobs"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("controller")));
+    }
+}

--- a/src/test/java/com/youtube/ai/scheduler/JobServiceTest.java
+++ b/src/test/java/com/youtube/ai/scheduler/JobServiceTest.java
@@ -1,0 +1,72 @@
+package com.youtube.ai.scheduler;
+
+import com.youtube.ai.scheduler.model.Job;
+import com.youtube.ai.scheduler.repository.JobRepository;
+import com.youtube.ai.scheduler.service.JobService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@org.springframework.transaction.annotation.Transactional
+class JobServiceTest {
+
+    @Autowired
+    private JobService jobService;
+    @Autowired
+    private JobRepository jobRepository;
+
+    @TempDir
+    Path tempDir;
+
+    private Path createScript(String name) throws Exception {
+        Path script = tempDir.resolve(name);
+        Files.write(script, List.of("#!/bin/bash", "echo test"));
+        script.toFile().setExecutable(true);
+        return script;
+    }
+
+    @Test
+    void saveAndRunJob() throws Exception {
+        Path script = createScript("run.sh");
+
+        Job job = new Job();
+        job.setName("test");
+        job.setScriptPath(script.toString());
+        job.setCronExpression("0/1 * * * * *");
+        job.setActive(true);
+
+        jobService.save(job);
+
+        List<Job> jobs = jobService.listJobs();
+        assertEquals(1, jobs.size());
+
+        jobService.runJob(jobs.get(0));
+    }
+
+    @Test
+    void deleteJob() throws Exception {
+        Path script = createScript("delete.sh");
+
+        Job job = new Job();
+        job.setName("del");
+        job.setScriptPath(script.toString());
+        job.setCronExpression("0/1 * * * * *");
+        job.setActive(true);
+
+        Job saved = jobService.save(job);
+        assertFalse(jobService.listJobs().isEmpty());
+
+        jobService.delete(saved.getId());
+        assertTrue(jobService.listJobs().isEmpty());
+    }
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,2 @@
+spring.sql.init.mode=never
+spring.jpa.hibernate.ddl-auto=create-drop


### PR DESCRIPTION
## Summary
- add JaCoCo and enforce 60% coverage
- create service/controller tests
- style HTML templates with new stylesheet

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_684b436a756c8322ab62ca00c0ca77d2