### PR TITLE
Support script parameters in scheduler jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,8 @@ Use helper scripts for common tasks:
 - `sh sh_scripts/run_generation_pipeline.sh` - generate video, description, thumbnail and title sequentially.
 - `sh sh_scripts/run_pipeline_and_upload.sh <hours>` - optional duration parameter then upload the result.
 - `sh sh_scripts/run_video_and_stream.sh <hours>` - generate a long video and start streaming.
+
+When scheduling jobs via the web UI you can also specify optional parameters that
+will be passed to the script. For example a job with `scriptPath` set to
+`sh_scripts/run_video_and_stream.sh` and `scriptParams` of `12` will start a
+12 hour stream.

--- a/read.me
+++ b/read.me
@@ -25,3 +25,8 @@ Use helper scripts for common tasks:
 - `sh sh_scripts/run_generation_pipeline.sh` - generate video, description, thumbnail and title sequentially.
 - `sh sh_scripts/run_pipeline_and_upload.sh <hours>` - optional duration parameter then upload the result.
 - `sh sh_scripts/run_video_and_stream.sh <hours>` - generate a long video and start streaming.
+
+When scheduling jobs via the web UI you can also specify optional parameters that
+will be passed to the script. For example a job with `scriptPath` set to
+`sh_scripts/run_video_and_stream.sh` and `scriptParams` of `12` will start a
+12 hour stream.

--- a/src/main/java/com/youtube/ai/scheduler/model/Job.java
+++ b/src/main/java/com/youtube/ai/scheduler/model/Job.java
@@ -11,6 +11,7 @@ public class Job {
 
     private String name;
     private String scriptPath;
+    private String scriptParams;
     private String cronExpression;
     private String nextScript1;
     private String nextScript2;
@@ -25,6 +26,9 @@ public class Job {
 
     public String getScriptPath() { return scriptPath; }
     public void setScriptPath(String scriptPath) { this.scriptPath = scriptPath; }
+
+    public String getScriptParams() { return scriptParams; }
+    public void setScriptParams(String scriptParams) { this.scriptParams = scriptParams; }
 
     public String getCronExpression() { return cronExpression; }
     public void setCronExpression(String cronExpression) { this.cronExpression = cronExpression; }

--- a/src/main/java/com/youtube/ai/scheduler/service/JobService.java
+++ b/src/main/java/com/youtube/ai/scheduler/service/JobService.java
@@ -60,7 +60,14 @@ public class JobService {
 
         for (String script : scripts) {
             logger.info("Running script {} for job {}", script, job.getName());
-            ProcessBuilder pb = new ProcessBuilder("bash", script);
+            List<String> command = new ArrayList<>();
+            command.add("bash");
+            command.add(script);
+            if (job.getScriptParams() != null && !job.getScriptParams().isBlank()) {
+                String[] params = job.getScriptParams().split("\\s+");
+                command.addAll(Arrays.asList(params));
+            }
+            ProcessBuilder pb = new ProcessBuilder(command);
             pb.redirectErrorStream(true);
             Process proc = pb.start();
             try (BufferedReader reader = new BufferedReader(

--- a/src/main/resources/init.sql
+++ b/src/main/resources/init.sql
@@ -1,3 +1,3 @@
-INSERT INTO job (name, script_path, cron_expression, next_script1, next_script2, active) VALUES
-  ('Example 6h Upload', 'sh_scripts/run_pipeline_and_upload_6h.sh', '0 0 6 * * *', NULL, NULL, true),
-  ('Example 12h Stream', 'sh_scripts/run_video_and_stream_12h.sh', '0 0 18 * * *', NULL, NULL, true);
+INSERT INTO job (name, script_path, script_params, cron_expression, next_script1, next_script2, active) VALUES
+  ('Daily 12h Stream', 'sh_scripts/run_video_and_stream.sh', '12', '0 0 0 * * *', NULL, NULL, true),
+  ('Daily 6h Upload', 'sh_scripts/run_pipeline_and_upload.sh', '6', '0 0 15 * * *', NULL, NULL, true);

--- a/src/main/resources/templates/form.html
+++ b/src/main/resources/templates/form.html
@@ -11,6 +11,7 @@
 <form action="/jobs" method="post" th:object="${job}">
     <input type="text" th:field="*{name}" placeholder="Görev Adı"/><br/>
     <input type="text" th:field="*{scriptPath}" placeholder="Ana SH Dosyası"/><br/>
+    <input type="text" th:field="*{scriptParams}" placeholder="Script Parametreleri"/><br/>
     <input type="text" th:field="*{cronExpression}" placeholder="Cron İfadesi (örn: 0 0 * * *)"/><br/>
     <input type="text" th:field="*{nextScript1}" placeholder="2. SH (isteğe bağlı)"/><br/>
     <input type="text" th:field="*{nextScript2}" placeholder="3. SH (isteğe bağlı)"/><br/>

--- a/src/main/resources/templates/list.html
+++ b/src/main/resources/templates/list.html
@@ -10,10 +10,11 @@
 <h2>Tanımlı Görevler</h2>
 <a href="/jobs/new">Yeni Görev</a>
 <table>
-<tr><th>Ad</th><th>Script</th><th>Cron</th><th>İşlem</th></tr>
+<tr><th>Ad</th><th>Script</th><th>Param</th><th>Cron</th><th>İşlem</th></tr>
 <tr th:each="job : ${jobs}">
     <td th:text="${job.name}">Ad</td>
     <td th:text="${job.scriptPath}">Script</td>
+    <td th:text="${job.scriptParams}">Param</td>
     <td th:text="${job.cronExpression}">Cron</td>
     <td>
         <a th:href="@{'/jobs/run/' + ${job.id}}">Çalıştır</a>

--- a/src/test/java/com/youtube/ai/scheduler/JobControllerTest.java
+++ b/src/test/java/com/youtube/ai/scheduler/JobControllerTest.java
@@ -40,6 +40,7 @@ class JobControllerTest {
         Job job = new Job();
         job.setName("controller");
         job.setScriptPath(script.toString());
+        job.setScriptParams("p1");
         job.setCronExpression("* * * * *");
         job.setActive(false);
         return repository.save(job);

--- a/src/test/java/com/youtube/ai/scheduler/JobServiceTest.java
+++ b/src/test/java/com/youtube/ai/scheduler/JobServiceTest.java
@@ -42,6 +42,7 @@ class JobServiceTest {
         Job job = new Job();
         job.setName("test");
         job.setScriptPath(script.toString());
+        job.setScriptParams("foo bar");
         job.setCronExpression("0/1 * * * * *");
         job.setActive(true);
 
@@ -60,6 +61,7 @@ class JobServiceTest {
         Job job = new Job();
         job.setName("del");
         job.setScriptPath(script.toString());
+        job.setScriptParams("baz");
         job.setCronExpression("0/1 * * * * *");
         job.setActive(true);
 


### PR DESCRIPTION
## Summary
- add `scriptParams` field to `Job`
- pass parameters to scripts when running jobs
- extend HTML forms and list to show parameters
- seed DB with daily streaming/upload jobs using parameterized scripts
- update tests and documentation

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_684c9e86e13c8322a6e804fc995885d0