### PR TITLE
Add optional Twitter post step

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,17 @@ When scheduling jobs via the web UI you can also specify optional parameters tha
 will be passed to the script. For example a job with `scriptPath` set to
 `sh_scripts/run_video_and_stream.sh` and `scriptParams` of `12` will start a
 12 hour stream.
+
+## Twitter Posting
+Set your Twitter API credentials in `sh_scripts/config.conf`:
+```
+TWITTER_API_KEY="..."
+TWITTER_API_SECRET="..."
+TWITTER_ACCESS_TOKEN="..."
+TWITTER_ACCESS_SECRET="..."
+```
+After uploading a video or starting a stream you can notify followers with:
+```
+sh sh_scripts/post_to_twitter.sh "Check out my new video!"
+```
+If you want this to happen automatically, set `nextScript1` in your job configuration to `sh_scripts/post_to_twitter.sh` (see `src/main/resources/init.sql`).

--- a/sh_scripts/config.conf
+++ b/sh_scripts/config.conf
@@ -50,3 +50,9 @@ OPENAI_MODEL="gpt-3.5-turbo"
 KEYWORDS="lofi, study music, chillhop"
 
 # Additional default settings can be added here
+
+# === Twitter API Settings ===
+TWITTER_API_KEY=""
+TWITTER_API_SECRET=""
+TWITTER_ACCESS_TOKEN=""
+TWITTER_ACCESS_SECRET=""

--- a/sh_scripts/post_to_twitter.sh
+++ b/sh_scripts/post_to_twitter.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# post_to_twitter.sh - Post a tweet about the uploaded video or stream
+
+CONFIG_FILE="${1:-$(dirname "$0")/config.conf}"
+MESSAGE="$2"
+
+if [ -f "$CONFIG_FILE" ]; then
+    # shellcheck disable=SC1090
+    source "$CONFIG_FILE"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+URL_FILE="$SCRIPT_DIR/latest_video_url.txt"
+if [ -z "$VIDEO_URL" ] && [ -f "$URL_FILE" ]; then
+    VIDEO_URL="$(cat "$URL_FILE")"
+fi
+
+# Validate credentials
+if [ -z "$TWITTER_API_KEY" ] || [ -z "$TWITTER_API_SECRET" ] || [ -z "$TWITTER_ACCESS_TOKEN" ] || [ -z "$TWITTER_ACCESS_SECRET" ]; then
+    echo "Twitter API credentials are missing in config.conf" >&2
+    exit 1
+fi
+
+# Default message if none provided
+if [ -z "$MESSAGE" ]; then
+    STYLE="${VIDEO_STYLE:-${KEYWORDS:-lofi beats}}"
+    if [ -n "$VIDEO_URL" ]; then
+        MESSAGE="New $STYLE video uploaded! Watch here: $VIDEO_URL"
+    else
+        MESSAGE="Enjoy our latest $STYLE content!"
+    fi
+fi
+
+export TWITTER_API_KEY TWITTER_API_SECRET TWITTER_ACCESS_TOKEN TWITTER_ACCESS_SECRET TWEET_MESSAGE="$MESSAGE"
+
+python3 - <<'PY'
+import os
+try:
+    import tweepy
+except ImportError:
+    import subprocess, sys
+    subprocess.check_call([sys.executable, '-m', 'pip', 'install', '--quiet', 'tweepy'])
+    import tweepy
+
+api_key = os.environ['TWITTER_API_KEY']
+api_secret = os.environ['TWITTER_API_SECRET']
+access_token = os.environ['TWITTER_ACCESS_TOKEN']
+access_secret = os.environ['TWITTER_ACCESS_SECRET']
+message = os.environ['TWEET_MESSAGE']
+
+auth = tweepy.OAuth1UserHandler(api_key, api_secret, access_token, access_secret)
+api = tweepy.API(auth)
+api.update_status(status=message)
+PY

--- a/sh_scripts/run_pipeline_and_upload.sh
+++ b/sh_scripts/run_pipeline_and_upload.sh
@@ -11,4 +11,9 @@ fi
 
 bash "$SCRIPT_DIR/cleanup_outputs.sh" "$CONFIG_FILE"
 bash "$SCRIPT_DIR/run_generation_pipeline.sh" "$CONFIG_FILE"
-bash "$SCRIPT_DIR/upload_video.sh" "$CONFIG_FILE"
+UPLOAD_OUTPUT=$(bash "$SCRIPT_DIR/upload_video.sh" "$CONFIG_FILE")
+echo "$UPLOAD_OUTPUT"
+VIDEO_URL=$(echo "$UPLOAD_OUTPUT" | grep -o 'https://youtu.be/[A-Za-z0-9_-]*')
+if [ -n "$VIDEO_URL" ]; then
+    echo "$VIDEO_URL" > "$SCRIPT_DIR/latest_video_url.txt"
+fi

--- a/src/main/resources/init.sql
+++ b/src/main/resources/init.sql
@@ -1,3 +1,3 @@
 INSERT INTO job (name, script_path, script_params, cron_expression, next_script1, next_script2, active) VALUES
-  ('Daily 12h Stream', 'sh_scripts/run_video_and_stream.sh', '12', '0 0 0 * * *', NULL, NULL, true),
-  ('Daily 6h Upload', 'sh_scripts/run_pipeline_and_upload.sh', '6', '0 0 15 * * *', NULL, NULL, true);
+  ('Daily 12h Stream', 'sh_scripts/run_video_and_stream.sh', '12', '0 0 0 * * *', 'sh_scripts/post_to_twitter.sh', NULL, true),
+  ('Daily 6h Upload', 'sh_scripts/run_pipeline_and_upload.sh', '6', '0 0 15 * * *', 'sh_scripts/post_to_twitter.sh', NULL, true);


### PR DESCRIPTION
## Summary
- keep Twitter credentials config
- store latest video URL for optional tweet step
- tweet script loads URL from file if provided
- jobs run `post_to_twitter.sh` via `nextScript1`
- update docs accordingly

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_684ca014371483229e69574bef344a9b