### PR TITLE
Fix cron expression placeholder and seed data

### DIFF
--- a/src/main/resources/init.sql
+++ b/src/main/resources/init.sql
@@ -1,4 +1,4 @@
 INSERT INTO job (name, script_path, script_params, cron_expression, next_script1, next_script2, active, last_log, last_exit_code, sequence) VALUES
   ('Daily 12h Stream', 'sh_scripts/run_video_and_stream.sh', '12 --tag lofi --post-twitter', '0 0 0 * * *', NULL, NULL, true, NULL, NULL, 1),
   ('Daily 6h Upload', 'sh_scripts/run_pipeline_and_upload.sh', '6 --tag lofi --post-twitter', '0 0 15 * * *', NULL, NULL, true, NULL, NULL, 2),
-  ('Daily Tweet', 'sh_scripts/post_to_twitter.sh', '--tag lofi', '30 12 * * *', NULL, NULL, true, NULL, NULL, 3);
+  ('Daily Tweet', 'sh_scripts/post_to_twitter.sh', '--tag lofi', '0 30 12 * * *', NULL, NULL, true, NULL, NULL, 3);

--- a/src/main/resources/templates/form.html
+++ b/src/main/resources/templates/form.html
@@ -12,7 +12,7 @@
     <input type="text" th:field="*{name}" placeholder="Görev Adı"/><br/>
     <input type="text" th:field="*{scriptPath}" placeholder="Ana SH Dosyası"/><br/>
     <input type="text" th:field="*{scriptParams}" placeholder="Script Parametreleri"/><br/>
-    <input type="text" th:field="*{cronExpression}" placeholder="Cron İfadesi (örn: 0 0 * * *)"/><br/>
+    <input type="text" th:field="*{cronExpression}" placeholder="Cron İfadesi (örn: 0 0 12 * * *)"/><br/>
     <input type="text" th:field="*{nextScript1}" placeholder="2. SH (isteğe bağlı)"/><br/>
     <input type="text" th:field="*{nextScript2}" placeholder="3. SH (isteğe bağlı)"/><br/>
     <label>Aktif mi? <input type="checkbox" th:field="*{active}"/></label><br/>


### PR DESCRIPTION
## Summary
- fix sample cron expressions in `init.sql` and form placeholder

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_684cad23e8d88322b1a848b09b7e4359