### PR TITLE
Fix twitter config passed in pipeline script

### DIFF
--- a/sh_scripts/run_pipeline_and_upload.sh
+++ b/sh_scripts/run_pipeline_and_upload.sh
@@ -57,5 +57,9 @@ if [ "$RUN_UPLOAD" -eq 1 ]; then
 fi
 
 if [ "$POST_TWITTER" -eq 1 ]; then
-    bash "$SCRIPT_DIR/post_to_twitter.sh" "$CONFIG_OVERRIDE"
+    if [ -n "$CONFIG_OVERRIDE" ]; then
+        bash "$SCRIPT_DIR/post_to_twitter.sh" --config "$CONFIG_OVERRIDE"
+    else
+        bash "$SCRIPT_DIR/post_to_twitter.sh"
+    fi
 fi


### PR DESCRIPTION
## Summary
- ensure `run_pipeline_and_upload.sh` passes the config path to `post_to_twitter.sh`

## Testing
- `./gradlew test`
- `CHANNEL=test bash sh_scripts/run_pipeline_and_upload.sh --post-twitter --config sh_scripts/configs/test.conf --no-generation --no-upload` *(fails: ProxyError - api.twitter.com)*

------
https://chatgpt.com/codex/tasks/task_e_684cc62cbc4c8322956f9fd0e1fec2aa