### PR TITLE
Handle missing Twitter credentials gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ TWITTER_API_SECRET="..."
 TWITTER_ACCESS_TOKEN="..."
 TWITTER_ACCESS_SECRET="..."
 ```
+If these variables are empty the `post_to_twitter.sh` script logs a message and exits without posting.
 After uploading a video or starting a stream you can notify followers with:
 ```
 sh sh_scripts/post_to_twitter.sh

--- a/read.me
+++ b/read.me
@@ -71,7 +71,7 @@ will be passed to the script. For example a job with `scriptPath` set to
 
 See `src/main/resources/init.sql` for sample jobs including a standalone tweet job that runs `post_to_twitter.sh --tag lofi`. Each entry sets a `channel` so the scheduler loads the right credentials.
 
-Twitter credentials are loaded from the selected channel configuration. Run:
+Twitter credentials are loaded from the selected channel configuration. If they are missing the Twitter posting script just logs a message and exits. Run:
 ```bash
 sh sh_scripts/post_to_twitter.sh --tag lofi
 ```

--- a/sh_scripts/post_to_twitter.sh
+++ b/sh_scripts/post_to_twitter.sh
@@ -38,8 +38,8 @@ fi
 
 # Validate credentials
 if [ -z "$TWITTER_API_KEY" ] || [ -z "$TWITTER_API_SECRET" ] || [ -z "$TWITTER_ACCESS_TOKEN" ] || [ -z "$TWITTER_ACCESS_SECRET" ]; then
-    echo "Twitter API credentials are missing in channels.env" >&2
-    exit 1
+    echo "Twitter API credentials are missing, skipping tweet" >&2
+    exit 0
 fi
 
 # Default message if none provided


### PR DESCRIPTION
## Summary
- tweet script returns success when credentials are missing
- document the skip behavior in README files

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684cba1a778883229510ddcf32a03a83