### PR TITLE
Update streaming script to use generation pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,12 @@ Use helper scripts for common tasks:
 
 - `sh sh_scripts/run_generation_pipeline.sh` - generate video, description, thumbnail and title sequentially.
 - `sh sh_scripts/run_pipeline_and_upload.sh <hours> [options]` - run the pipeline and optionally upload and tweet.
-- `sh sh_scripts/run_video_and_stream.sh <hours> [options]` - generate a long video, stream it and optionally tweet.
+- `sh sh_scripts/run_pipeline_and_stream.sh <hours> [options]` - run the pipeline then stream the result and optionally tweet.
+
 
 When scheduling jobs via the web UI you can also specify optional parameters that
 will be passed to the script. For example a job with `scriptPath` set to
-`sh_scripts/run_video_and_stream.sh` and `scriptParams` of `12 --post-twitter --tag lofi` will start a
+`sh_scripts/run_pipeline_and_stream.sh` and `scriptParams` of `12 --post-twitter --tag lofi` will start a
 12 hour stream and post to Twitter using the `lofi` tag.
 
 `src/main/resources/init.sql` includes sample jobs for daily streaming, uploading,

--- a/read.me
+++ b/read.me
@@ -62,11 +62,11 @@ Use helper scripts for common tasks:
 
 - `sh sh_scripts/run_generation_pipeline.sh` - generate video, description, thumbnail and title sequentially.
 - `sh sh_scripts/run_pipeline_and_upload.sh <hours> [options]` - run the pipeline and optionally upload and tweet.
-- `sh sh_scripts/run_video_and_stream.sh <hours> [options]` - generate a long video, stream it and optionally tweet.
+- `sh sh_scripts/run_pipeline_and_stream.sh <hours> [options]` - run the pipeline then stream the result and optionally tweet.
 
 When scheduling jobs via the web UI you can also specify optional parameters that
 will be passed to the script. For example a job with `scriptPath` set to
-`sh_scripts/run_video_and_stream.sh` and `scriptParams` of `12 --post-twitter --tag lofi` will start a
+`sh_scripts/run_pipeline_and_stream.sh` and `scriptParams` of `12 --post-twitter --tag lofi` will start a
 12 hour stream and post to Twitter using the `lofi` tag.
 
 See `src/main/resources/init.sql` for sample jobs including a standalone tweet job that runs `post_to_twitter.sh --tag lofi`. Each entry sets a `channel` so the scheduler loads the right credentials.

--- a/sh_scripts/run_pipeline_and_stream.sh
+++ b/sh_scripts/run_pipeline_and_stream.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# run_video_and_stream.sh - set duration then generate video and stream
+# run_pipeline_and_stream.sh - set duration then run generation pipeline and stream
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
@@ -10,7 +10,6 @@ source "$SCRIPT_DIR/common.sh"
 load_channel_config "${CHANNEL:-default}"
 POST_TWITTER=0
 TAG=""
-
 # Parse args
 if [[ "$1" =~ ^[0-9] ]]; then
     DURATION_HOURS="$1"
@@ -33,8 +32,7 @@ done
 bash "$SCRIPT_DIR/update_config.sh" VIDEO_DURATION_HOURS "$DURATION_HOURS" "$CONFIG_OVERRIDE"
 [ -n "$TAG" ] && bash "$SCRIPT_DIR/update_config.sh" TAG "$TAG" "$CONFIG_OVERRIDE"
 
-bash "$SCRIPT_DIR/cleanup_outputs.sh" "$CONFIG_OVERRIDE"
-bash "$SCRIPT_DIR/generate_video.sh" "$CONFIG_OVERRIDE"
+bash "$SCRIPT_DIR/run_generation_pipeline.sh" "$CONFIG_OVERRIDE"
 bash "$SCRIPT_DIR/upload_and_stream.sh" "$CONFIG_OVERRIDE"
 
 if [ "$POST_TWITTER" -eq 1 ]; then

--- a/sh_scripts/run_pipeline_and_upload.sh
+++ b/sh_scripts/run_pipeline_and_upload.sh
@@ -43,7 +43,6 @@ done
 [ -n "$TAG" ] && bash "$SCRIPT_DIR/update_config.sh" TAG "$TAG" "$CONFIG_OVERRIDE"
 
 if [ "$RUN_GENERATION" -eq 1 ]; then
-    bash "$SCRIPT_DIR/cleanup_outputs.sh" "$CONFIG_OVERRIDE"
     bash "$SCRIPT_DIR/run_generation_pipeline.sh" "$CONFIG_OVERRIDE"
 fi
 

--- a/src/main/resources/init.sql
+++ b/src/main/resources/init.sql
@@ -1,4 +1,4 @@
 INSERT INTO job (name, script_path, script_params, channel, cron_expression, next_script1, next_script2, active, last_log, last_exit_code, sequence) VALUES
-  ('Daily 12h Stream', 'sh_scripts/run_video_and_stream.sh', '12 --tag lofi --post-twitter', 'default', '0 0 0 * * *', NULL, NULL, true, NULL, NULL, 1),
+  ('Daily 12h Stream', 'sh_scripts/run_pipeline_and_stream.sh', '12 --tag lofi --post-twitter', 'default', '0 0 0 * * *', NULL, NULL, true, NULL, NULL, 1),
   ('Daily 6h Upload', 'sh_scripts/run_pipeline_and_upload.sh', '6 --tag lofi --post-twitter', 'default', '0 0 15 * * *', NULL, NULL, true, NULL, NULL, 2),
   ('Daily Tweet', 'sh_scripts/post_to_twitter.sh', '--tag lofi', 'default', '0 30 12 * * *', NULL, NULL, true, NULL, NULL, 3);


### PR DESCRIPTION
## Summary
- rename `run_video_and_stream.sh` to `run_pipeline_and_stream.sh`
- remove old helper `generate_video_only.sh`
- call generation pipeline from both upload and stream helpers
- update docs and example jobs

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_684cdd13cb388322a7ffd1fb91c26245