### PR TITLE
Add Google Drive fallback for GIF generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ KEYWORDS="lofi, study music"
 USE_OPENAI_GIF=0              # Set to 1 to create a GIF with OpenAI
 AI_GIF_PROMPT="lofi city at night animation"
 AI_GIF_MODEL="dall-e-2"      # or dall-e-3 for higher quality
+USE_GOOGLE_DRIVE=1           # Fallback if OpenAI GIF generation fails
+DRIVE_FOLDER_ID="1SevV-LKA67CVmEimWUwWicdJ0Eud6nHm"
 ```
 
 Per-channel credentials are kept in `sh_scripts/channels.env` as a JSON array.

--- a/sh_scripts/configs/base.conf
+++ b/sh_scripts/configs/base.conf
@@ -14,8 +14,8 @@ YOUTUBE_STREAM_URL="rtmp://a.rtmp.youtube.com/live2"
 
 # === Yerel Video Ayarları ===
 VIDEO_SOURCE_DIR="./video"
-USE_GOOGLE_DRIVE=0
-# DRIVE_FOLDER_ID=""
+USE_GOOGLE_DRIVE=1
+DRIVE_FOLDER_ID="1SevV-LKA67CVmEimWUwWicdJ0Eud6nHm"
 
 # OpenAI GIF Ayarları
 USE_OPENAI_GIF=0

--- a/sh_scripts/generate_video.sh
+++ b/sh_scripts/generate_video.sh
@@ -31,6 +31,24 @@ if [ "${USE_OPENAI_GIF:-0}" -eq 1 ]; then
     fi
 fi
 
+# OpenAI başarısız olduysa Google Drive'dan dosya indir
+if [ -z "$VIDEO_FILE" ] && [ "${USE_GOOGLE_DRIVE:-0}" -eq 1 ] && [ -n "$DRIVE_FOLDER_ID" ]; then
+    if command -v gdown >/dev/null 2>&1; then
+        echo ">> Google Drive'dan arkaplan dosyası indiriliyor..."
+        TMP_DRIVE_DIR=$(mktemp -d)
+        gdown --quiet --folder "https://drive.google.com/drive/folders/${DRIVE_FOLDER_ID}" -O "$TMP_DRIVE_DIR" --remaining-ok
+        DRIVE_FILE=$(find "$TMP_DRIVE_DIR" -type f \( -iname '*.mp4' -o -iname '*.gif' \) | shuf -n 1)
+        if [ -n "$DRIVE_FILE" ]; then
+            VIDEO_FILE="$DRIVE_FILE"
+            echo ">> İndirilen dosya: $VIDEO_FILE"
+        else
+            echo "HATA: Google Drive klasöründe uygun dosya bulunamadı." >&2
+        fi
+    else
+        echo "HATA: gdown aracı yüklü değil, Google Drive kullanılamıyor." >&2
+    fi
+fi
+
 if [ -z "$VIDEO_FILE" ]; then
     if [ -n "$BACKGROUND_VIDEO" ] && [ -f "$BACKGROUND_VIDEO" ]; then
         VIDEO_FILE="$BACKGROUND_VIDEO"


### PR DESCRIPTION
## Summary
- enable Google Drive configuration in `base.conf`
- document Google Drive fallback variables in README
- if OpenAI GIF generation fails, download a random GIF/video from the configured Drive folder

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_684da3e1e7b48322a3c2053875a87832