### PR TITLE
Support dynamic output video names

### DIFF
--- a/sh_scripts/cleanup_outputs.sh
+++ b/sh_scripts/cleanup_outputs.sh
@@ -6,8 +6,7 @@ CONFIG_OVERRIDE="${1:-}"
 source "$SCRIPT_DIR/common.sh"
 load_channel_config "${CHANNEL:-default}" "$CONFIG_OVERRIDE"
 
-# Remove generated video if exists
-[ -n "$OUTPUT_VIDEO" ] && rm -f "$OUTPUT_VIDEO"
+# Generated videoları saklamak için artık silmiyoruz
 
 # Remove mp3 files in MUSIC_DIR if set
 if [ -n "$MUSIC_DIR" ] && [ -d "$MUSIC_DIR" ]; then

--- a/sh_scripts/configs/base.conf
+++ b/sh_scripts/configs/base.conf
@@ -1,7 +1,7 @@
 # === Video ve Müzik Ayarları ===
-MUSIC_DIR="./mp3"
-OUTPUT_VIDEO="./output.mp4"
-VIDEO_DURATION_HOURS="1"
+: "${MUSIC_DIR:=./mp3}"
+: "${OUTPUT_VIDEO:=./output.mp4}"
+: "${VIDEO_DURATION_HOURS:=1}"
 
 VIDEO_CODEC="libx264"
 AUDIO_CODEC="aac"

--- a/sh_scripts/generate_description.sh
+++ b/sh_scripts/generate_description.sh
@@ -6,6 +6,9 @@ CONFIG_OVERRIDE="${1:-}"
 source "$SCRIPT_DIR/common.sh"
 load_channel_config "${CHANNEL:-default}" "$CONFIG_OVERRIDE"
 
+LATEST_FILE="$SCRIPT_DIR/latest_output_video.txt"
+[ -f "$LATEST_FILE" ] && OUTPUT_VIDEO="$(cat "$LATEST_FILE")"
+
 if [ -z "$OUTPUT_VIDEO" ] || [ ! -f "$OUTPUT_VIDEO" ]; then
     echo "Video dosyası bulunamadı: $OUTPUT_VIDEO" >&2
     exit 1

--- a/sh_scripts/generate_thumbnail_from_video.sh
+++ b/sh_scripts/generate_thumbnail_from_video.sh
@@ -6,6 +6,9 @@ CONFIG_OVERRIDE="${1:-}"
 . "$SCRIPT_DIR/common.sh"
 load_channel_config "${CHANNEL:-default}" "$CONFIG_OVERRIDE"
 
+LATEST_FILE="$SCRIPT_DIR/latest_output_video.txt"
+[ -f "$LATEST_FILE" ] && OUTPUT_VIDEO="$(cat "$LATEST_FILE")"
+
 # Ensure OUTPUT_VIDEO is set and exists
 if [ -z "$OUTPUT_VIDEO" ] || [ ! -f "$OUTPUT_VIDEO" ]; then
   echo "❌ HATA: OUTPUT_VIDEO tanımlı değil veya dosya bulunamadı: $OUTPUT_VIDEO" >&2

--- a/sh_scripts/generate_title.sh
+++ b/sh_scripts/generate_title.sh
@@ -6,6 +6,9 @@ CONFIG_OVERRIDE="${1:-}"
 source "$SCRIPT_DIR/common.sh"
 load_channel_config "${CHANNEL:-default}" "$CONFIG_OVERRIDE"
 
+LATEST_FILE="$SCRIPT_DIR/latest_output_video.txt"
+[ -f "$LATEST_FILE" ] && OUTPUT_VIDEO="$(cat "$LATEST_FILE")"
+
 DURATION_SOURCE="${OUTPUT_VIDEO:-$VIDEO_FILE}"
 if [ -z "$DURATION_SOURCE" ] || [ ! -f "$DURATION_SOURCE" ]; then
     echo "Video dosyası bulunamadı: $DURATION_SOURCE" >&2

--- a/sh_scripts/generate_video.sh
+++ b/sh_scripts/generate_video.sh
@@ -4,12 +4,25 @@
 echo ">> Önceki geçici dosyalar temizleniyor..."
 rm -f /tmp/audio_list.txt /tmp/audio_list_ext.txt
 rm -rf /tmp/video_folder
-rm -f "$OUTPUT_VIDEO"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CONFIG_OVERRIDE="${1:-}"
 source "$SCRIPT_DIR/common.sh"
 load_channel_config "${CHANNEL:-default}" "$CONFIG_OVERRIDE"
+
+LATEST_FILE="$SCRIPT_DIR/latest_output_video.txt"
+if [ -f "$LATEST_FILE" ]; then
+  OUTPUT_VIDEO="$(cat "$LATEST_FILE")"
+else
+  DIR="$(dirname "$OUTPUT_VIDEO")"
+  BASE="$(basename "$OUTPUT_VIDEO")"
+  EXT="${BASE##*.}"
+  NAME="${BASE%.*}"
+  TIMESTAMP=$(date +'%Y%m%d_%H%M')
+  OUTPUT_VIDEO="$DIR/${NAME}_${TIMESTAMP}.${EXT}"
+  echo "$OUTPUT_VIDEO" > "$LATEST_FILE"
+fi
+export OUTPUT_VIDEO
 
 TARGET_SECONDS=$(echo "$VIDEO_DURATION_HOURS * 3600" | bc)
 TARGET_SECONDS=${TARGET_SECONDS%.*}  # Virgülden sonrasını at

--- a/sh_scripts/remote_stream.sh
+++ b/sh_scripts/remote_stream.sh
@@ -6,6 +6,9 @@ CONFIG_OVERRIDE="${1:-}"
 source "$SCRIPT_DIR/common.sh"
 load_channel_config "${CHANNEL:-default}" "$CONFIG_OVERRIDE"
 
+LATEST_FILE="$SCRIPT_DIR/latest_output_video.txt"
+[ -f "$LATEST_FILE" ] && OUTPUT_VIDEO="$(cat "$LATEST_FILE")"
+
 RTMP_URL="${YOUTUBE_STREAM_URL}/${YOUTUBE_STREAM_KEY}"
 
 echo ">> Önceki ffmpeg süreçleri kontrol ediliyor..."

--- a/sh_scripts/upload_and_stream.sh
+++ b/sh_scripts/upload_and_stream.sh
@@ -6,6 +6,9 @@ CONFIG_OVERRIDE="${1:-}"
 source "$SCRIPT_DIR/common.sh"
 load_channel_config "${CHANNEL:-default}" "$CONFIG_OVERRIDE"
 
+LATEST_FILE="$SCRIPT_DIR/latest_output_video.txt"
+[ -f "$LATEST_FILE" ] && OUTPUT_VIDEO="$(cat "$LATEST_FILE")"
+
 RTMP_URL="${YOUTUBE_STREAM_URL}/${YOUTUBE_STREAM_KEY}"
 
 if [ ! -f "$OUTPUT_VIDEO" ]; then
@@ -22,7 +25,7 @@ LOCAL_ENV_FILE="${CHANNEL_ENV_FILE:-$SCRIPT_DIR/channels.env}"
 
 echo ">> Dosyalar sunucuya gönderiliyor..."
 ssh -i "$PEM_FILE" "$REMOTE_USER@$REMOTE_HOST" "mkdir -p $REMOTE_DIR/configs"
-scp -i "$PEM_FILE" "$OUTPUT_VIDEO" remote_stream.sh common.sh "$LOCAL_ENV_FILE" "$REMOTE_USER@$REMOTE_HOST:$REMOTE_DIR/"
+scp -i "$PEM_FILE" "$OUTPUT_VIDEO" remote_stream.sh common.sh "$LOCAL_ENV_FILE" "$LATEST_FILE" "$REMOTE_USER@$REMOTE_HOST:$REMOTE_DIR/"
 scp -i "$PEM_FILE" "$LOCAL_CONFIG_FILE" "$REMOTE_USER@$REMOTE_HOST:$REMOTE_DIR/configs/base.conf"
 if [ $? -ne 0 ]; then
     echo "HATA: Dosya gönderimi başarısız oldu!" >&2

--- a/sh_scripts/upload_video.sh
+++ b/sh_scripts/upload_video.sh
@@ -10,6 +10,9 @@ source "$SCRIPT_DIR/common.sh"
 load_channel_config "${CHANNEL:-default}" "$CONFIG_OVERRIDE"
 CONFIG_FILE="$CONFIG_OVERRIDE"
 
+LATEST_FILE="$SCRIPT_DIR/latest_output_video.txt"
+[ -f "$LATEST_FILE" ] && OUTPUT_VIDEO="$(cat "$LATEST_FILE")"
+
 if [ -z "$CLIENT_ID" ] || [ -z "$CLIENT_SECRET" ] || [ -z "$REFRESH_TOKEN" ]; then
   echo "HATA: OAuth2 API bilgileri eksik."
   exit 1


### PR DESCRIPTION
## Summary
- keep prior videos by default
- set default variables via parameter expansion
- name generated videos with timestamp under `latest_output_video.txt`
- reference latest video in other scripts and when streaming
- copy latest video path when uploading to a stream server

## Testing
- `bash -n sh_scripts/generate_video.sh`
- `bash -n sh_scripts/generate_description.sh`
- `bash -n sh_scripts/generate_thumbnail_from_video.sh`
- `bash -n sh_scripts/generate_title.sh`
- `bash -n sh_scripts/upload_video.sh`
- `bash -n sh_scripts/upload_and_stream.sh`
- `bash -n sh_scripts/remote_stream.sh`
- `bash -n sh_scripts/cleanup_outputs.sh`


------
https://chatgpt.com/codex/tasks/task_e_684dadbf3f5c83229510c9e313566a94