### PR TITLE
Add manual runner form on job list

### DIFF
--- a/src/main/java/com/youtube/ai/scheduler/JobController.java
+++ b/src/main/java/com/youtube/ai/scheduler/JobController.java
@@ -24,6 +24,8 @@ public class JobController {
     @GetMapping
     public String listJobs(Model model) {
         model.addAttribute("jobs", jobService.listJobs());
+        model.addAttribute("scripts", jobService.listScripts());
+        model.addAttribute("channels", jobService.listChannels());
         return "list";
     }
 
@@ -63,6 +65,43 @@ public class JobController {
     public String schedulePage(Model model) {
         model.addAttribute("jobs", jobService.listJobs());
         return "schedule";
+    }
+
+    @GetMapping("/manual")
+    public String manualPage(Model model) {
+        model.addAttribute("scripts", jobService.listScripts());
+        model.addAttribute("channels", jobService.listChannels());
+        return "manual";
+    }
+
+    @PostMapping("/manual")
+    public String runManual(@RequestParam String script,
+                            @RequestParam String channel,
+                            @RequestParam(required = false) String params) {
+        Job job = new Job();
+        job.setName("manual");
+        job.setScriptPath(script);
+        job.setScriptParams(params);
+        job.setChannel(channel);
+        try {
+            jobService.runJob(job);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return "redirect:/jobs";
+    }
+
+    @GetMapping("/calendar")
+    public String calendar(Model model) {
+        model.addAttribute("entries", jobService.getWeeklySchedule());
+        java.util.List<String> channels = jobService.listChannels();
+        java.util.Map<String, String> colors = new java.util.HashMap<>();
+        String[] palette = {"red","blue","green","orange","purple","brown","teal"};
+        for (int i=0;i<channels.size();i++) {
+            colors.put(channels.get(i), palette[i % palette.length]);
+        }
+        model.addAttribute("channelColors", colors);
+        return "calendar";
     }
 
     @PostMapping("/schedule")

--- a/src/main/java/com/youtube/ai/scheduler/model/ScheduleEntry.java
+++ b/src/main/java/com/youtube/ai/scheduler/model/ScheduleEntry.java
@@ -1,0 +1,25 @@
+package com.youtube.ai.scheduler.model;
+
+import java.time.LocalDateTime;
+
+public class ScheduleEntry {
+    private String jobName;
+    private String channel;
+    private LocalDateTime time;
+
+    public ScheduleEntry() {}
+    public ScheduleEntry(String jobName, String channel, LocalDateTime time) {
+        this.jobName = jobName;
+        this.channel = channel;
+        this.time = time;
+    }
+
+    public String getJobName() { return jobName; }
+    public void setJobName(String jobName) { this.jobName = jobName; }
+
+    public String getChannel() { return channel; }
+    public void setChannel(String channel) { this.channel = channel; }
+
+    public LocalDateTime getTime() { return time; }
+    public void setTime(LocalDateTime time) { this.time = time; }
+}

--- a/src/main/resources/templates/calendar.html
+++ b/src/main/resources/templates/calendar.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Haftalık Takvim</title>
+    <link rel="stylesheet" th:href="@{/styles.css}" />
+    <style>
+        table.calendar { border-collapse: collapse; width: 100%; }
+        table.calendar th, table.calendar td { border: 1px solid #ccc; padding: 4px; vertical-align: top; height: 40px; }
+        table.calendar th { background: #f0f0f0; }
+        .entry { display: block; }
+    </style>
+</head>
+<body>
+<h2>Haftalık Görev Takvimi</h2>
+<table class="calendar">
+    <thead>
+    <tr>
+        <th>Saat</th>
+        <th>Pzt</th>
+        <th>Sal</th>
+        <th>Çar</th>
+        <th>Per</th>
+        <th>Cum</th>
+        <th>Cmt</th>
+        <th>Paz</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr th:each="hour : ${#numbers.sequence(0,23)}">
+        <td th:text="${hour} + ':00'"></td>
+        <td th:each="day : ${#numbers.sequence(1,7)}">
+            <div th:each="e : ${entries}" th:if="${e.time.dayOfWeek.value} == ${day} and ${e.time.hour} == ${hour}" th:text="${e.jobName}" th:style="'color:' + ${channelColors[e.channel]}" class="entry"></div>
+        </td>
+    </tr>
+    </tbody>
+</table>
+<a href="/jobs">Geri</a>
+</body>
+</html>

--- a/src/main/resources/templates/list.html
+++ b/src/main/resources/templates/list.html
@@ -8,7 +8,9 @@
 </head>
 <body>
 <h2>Tanımlı Görevler</h2>
-<a href="/jobs/new">Yeni Görev</a> | <a href="/jobs/schedule">Sıralamayı Düzenle</a>
+<a href="/jobs/new">Yeni Görev</a> |
+<a href="/jobs/schedule">Sıralamayı Düzenle</a> |
+<a href="/jobs/calendar">Takvim</a>
 <table>
 <tr><th>Ad</th><th>Script</th><th>Param</th><th>Cron</th><th>Durum</th><th>Son Log</th><th>İşlem</th><th>Loglar</th></tr>
 <tr th:each="job : ${jobs}">
@@ -25,5 +27,21 @@
     <td><a th:href="@{'/jobs/logs/' + ${job.id}}">Görüntüle</a></td>
 </tr>
 </table>
+
+<h3>Manuel SH Çalıştır</h3>
+<form action="/jobs/manual" method="post">
+    <label>Script:
+        <select name="script">
+            <option th:each="s : ${scripts}" th:value="${s}" th:text="${s}"></option>
+        </select>
+    </label>
+    <label>Kanal:
+        <select name="channel">
+            <option th:each="c : ${channels}" th:value="${c}" th:text="${c}"></option>
+        </select>
+    </label>
+    <input type="text" name="params" placeholder="Parametreler"/>
+    <button type="submit">Çalıştır</button>
+</form>
 </body>
 </html>

--- a/src/main/resources/templates/manual.html
+++ b/src/main/resources/templates/manual.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Manual Run</title>
+    <link rel="stylesheet" th:href="@{/styles.css}" />
+</head>
+<body>
+<h2>Manuel SH Çalıştır</h2>
+<form action="/jobs/manual" method="post">
+    <label>Script:
+        <select name="script">
+            <option th:each="s : ${scripts}" th:value="${s}" th:text="${s}"></option>
+        </select>
+    </label><br/>
+    <label>Kanal:
+        <select name="channel">
+            <option th:each="c : ${channels}" th:value="${c}" th:text="${c}"></option>
+        </select>
+    </label><br/>
+    <input type="text" name="params" placeholder="Parametreler"/><br/>
+    <button type="submit">Çalıştır</button>
+</form>
+<a href="/jobs">Geri</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- show manual execution form directly on the `/jobs` list page
- expose script and channel lists when loading the job list

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_684eb65b9b748322b7020be1550402b7