### PR TITLE
Improve calendar display for streaming durations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+.gradle/
+

--- a/src/main/java/com/youtube/ai/scheduler/model/ScheduleEntry.java
+++ b/src/main/java/com/youtube/ai/scheduler/model/ScheduleEntry.java
@@ -6,12 +6,15 @@ public class ScheduleEntry {
     private String jobName;
     private String channel;
     private LocalDateTime time;
+    // If true, this entry represents a video duration rather than live stream time
+    private boolean video;
 
     public ScheduleEntry() {}
-    public ScheduleEntry(String jobName, String channel, LocalDateTime time) {
+    public ScheduleEntry(String jobName, String channel, LocalDateTime time, boolean video) {
         this.jobName = jobName;
         this.channel = channel;
         this.time = time;
+        this.video = video;
     }
 
     public String getJobName() { return jobName; }
@@ -22,4 +25,7 @@ public class ScheduleEntry {
 
     public LocalDateTime getTime() { return time; }
     public void setTime(LocalDateTime time) { this.time = time; }
+
+    public boolean isVideo() { return video; }
+    public void setVideo(boolean video) { this.video = video; }
 }

--- a/src/main/resources/templates/calendar.html
+++ b/src/main/resources/templates/calendar.html
@@ -30,7 +30,11 @@
     <tr th:each="hour : ${#numbers.sequence(0,23)}">
         <td th:text="${hour} + ':00'"></td>
         <td th:each="day : ${#numbers.sequence(1,7)}">
-            <div th:each="e : ${entries}" th:if="${e.time.dayOfWeek.value} == ${day} and ${e.time.hour} == ${hour}" th:text="${e.jobName}" th:style="'color:' + ${channelColors[e.channel]}" class="entry"></div>
+            <div th:each="e : ${entries}"
+                 th:if="${e.time.dayOfWeek.value} == ${day} and ${e.time.hour} == ${hour}"
+                 th:text="${e.jobName}"
+                 th:style="'color:' + ${channelColors[e.channel]} + ';opacity:' + (${e.video} ? '0.4' : '1')"
+                 class="entry"></div>
         </td>
     </tr>
     </tbody>


### PR DESCRIPTION
## Summary
- add `.gitignore` for Gradle build artifacts
- include a `video` flag on `ScheduleEntry`
- parse job durations and create per-hour calendar entries
- show video hours with reduced opacity in calendar view

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684ef6f2927c832281e9dcedd00f0a77