### PR TITLE
Fix cron expression and improve calendar UI

### DIFF
--- a/src/main/java/com/youtube/ai/scheduler/JobController.java
+++ b/src/main/java/com/youtube/ai/scheduler/JobController.java
@@ -30,14 +30,20 @@ public class JobController {
     }
 
     @GetMapping("/new")
-    public String newJob(Model model) {
-        model.addAttribute("job", new Job());
+    public String newJob(Model model, @RequestParam(value = "cron", required = false) String cron) {
+        Job job = new Job();
+        if (cron != null) job.setCronExpression(cron);
+        model.addAttribute("job", job);
         return "form";
     }
 
     @PostMapping
-    public String saveJob(@ModelAttribute Job job) {
+    public String saveJob(@ModelAttribute Job job,
+                          @RequestParam(value = "returnTo", required = false) String returnTo) {
         jobService.save(job);
+        if (returnTo != null && !returnTo.isBlank()) {
+            return "redirect:" + returnTo;
+        }
         return "redirect:/jobs";
     }
 
@@ -94,6 +100,8 @@ public class JobController {
     @GetMapping("/calendar")
     public String calendar(Model model) {
         model.addAttribute("entries", jobService.getWeeklySchedule());
+        java.time.LocalDateTime start = java.time.LocalDate.now().atStartOfDay();
+        model.addAttribute("startDate", start);
         java.util.List<String> channels = jobService.listChannels();
         java.util.Map<String, String> colors = new java.util.HashMap<>();
         String[] palette = {"red","blue","green","orange","purple","brown","teal"};

--- a/src/main/resources/init.sql
+++ b/src/main/resources/init.sql
@@ -1,6 +1,6 @@
 INSERT INTO job (name, script_path, script_params, channel, cron_expression, next_script1, next_script2, active, last_log, last_exit_code, sequence) VALUES
   ('Daily 12h Stream', 'sh_scripts/run_pipeline_and_stream.sh', '12 --tag lofi --post-twitter --post-instagram', 'default', '0 0 0 * * *', NULL, NULL, true, NULL, NULL, 1),
   ('Daily 6h Upload', 'sh_scripts/run_pipeline_and_upload.sh', '6 --tag lofi --post-twitter', 'default', '0 0 15 * * *', NULL, NULL, true, NULL, NULL, 2),
-  ('Daily 1h Upload', 'sh_scripts/run_pipeline_and_upload.sh', '1 ', 'default', '0 3 30 * * *', NULL, NULL, true, NULL, NULL, 3),
+   ('Daily 1h Upload', 'sh_scripts/run_pipeline_and_upload.sh', '1 ', 'default', '0 30 3 * * *', NULL, NULL, true, NULL, NULL, 3),
   ('Daily Tweet', 'sh_scripts/post_to_twitter.sh', '--tag lofi', 'default', '0 30 12 * * *', NULL, NULL, true, NULL, NULL, 4),
   ('Daily Instagram Story', 'sh_scripts/post_instagram_story.sh', '', 'default', '0 0 11 * * *', NULL, NULL, true, NULL, NULL, 5);

--- a/src/main/resources/templates/calendar.html
+++ b/src/main/resources/templates/calendar.html
@@ -6,9 +6,13 @@
     <link rel="stylesheet" th:href="@{/styles.css}" />
     <style>
         table.calendar { border-collapse: collapse; width: 100%; }
-        table.calendar th, table.calendar td { border: 1px solid #ccc; padding: 4px; vertical-align: top; height: 40px; }
+        table.calendar th, table.calendar td { border: 1px solid #ccc; padding: 0; vertical-align: top; height: 40px; }
         table.calendar th { background: #f0f0f0; }
-        .entry { display: block; }
+        td.slot { display: flex; cursor: pointer; position: relative; }
+        .entry { flex: 1; margin: 1px; position: relative; border-radius: 3px; }
+        .entry:hover::after { content: attr(data-name); position: absolute; inset: 0; background: rgba(255,255,255,0.8); color: #000; display: flex; align-items: center; justify-content: center; font-size: 12px; }
+        #popup { display:none; position:fixed; top:20%; left:50%; transform:translate(-50%,-20%); background:#fff; padding:20px; border:1px solid #ccc; z-index:100; }
+        #popup input { margin:2px 0; }
     </style>
 </head>
 <body>
@@ -27,18 +31,47 @@
     </tr>
     </thead>
     <tbody>
-    <tr th:each="hour : ${#numbers.sequence(0,23)}">
-        <td th:text="${hour} + ':00'"></td>
-        <td th:each="day : ${#numbers.sequence(1,7)}">
-            <div th:each="e : ${entries}"
-                 th:if="${e.time.dayOfWeek.value} == ${day} and ${e.time.hour} == ${hour}"
-                 th:text="${e.jobName}"
-                 th:style="'color:' + ${channelColors[e.channel]} + ';opacity:' + (${e.video} ? '0.4' : '1')"
-                 class="entry"></div>
-        </td>
-    </tr>
+<tr th:each="hour : ${#numbers.sequence(0,23)}">
+    <td th:text="${hour} + ':00'"></td>
+    <td th:each="day : ${#numbers.sequence(1,7)}" class="slot" th:data-day="${day}" th:data-hour="${hour}" onclick="openCell(this)">
+        <div th:each="e : ${entries}"
+             th:if="${e.time.dayOfWeek.value} == ${day} and ${e.time.hour} == ${hour}"
+             th:style="'background-color:' + ${channelColors[e.channel]} + ';opacity:' + (${e.video} ? '0.4' : '1')"
+             th:attr="data-name=${e.jobName}"
+             class="entry"></div>
+    </td>
+</tr>
     </tbody>
 </table>
+<div id="popup">
+    <form action="/jobs" method="post" id="popupForm">
+        <input type="text" name="name" placeholder="Görev Adı" required/><br/>
+        <input type="text" name="scriptPath" placeholder="Ana SH Dosyası"/><br/>
+        <input type="text" name="scriptParams" placeholder="Script Parametreleri"/><br/>
+        <input type="text" name="channel" placeholder="Kanal"/><br/>
+        <input type="text" name="cronExpression" id="cronField"/><br/>
+        <label>Aktif mi? <input type="checkbox" name="active" checked/></label><br/>
+        <input type="hidden" name="returnTo" value="/jobs/calendar"/>
+        <button type="submit">Kaydet</button>
+        <button type="button" onclick="closePopup()">Kapat</button>
+    </form>
+</div>
+<script th:inline="javascript">
+    var startDate = new Date('[[${#dates.format(startDate, "yyyy-MM-dd'T'HH:mm:ss")}]]');
+    function openCell(td){
+        var day = parseInt(td.dataset.day);
+        var hour = parseInt(td.dataset.hour);
+        var dt = new Date(startDate.getTime());
+        dt.setDate(dt.getDate() + (day - 1));
+        dt.setHours(hour,0,0,0);
+        var cron = '0 ' + dt.getMinutes() + ' ' + dt.getHours() + ' ' + dt.getDate() + ' ' + (dt.getMonth()+1) + ' *';
+        document.getElementById('cronField').value = cron;
+        document.getElementById('popup').style.display='block';
+    }
+    function closePopup(){
+        document.getElementById('popup').style.display='none';
+    }
+</script>
 <a href="/jobs">Geri</a>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- correct invalid cron expression for Daily 1h Upload
- allow passing cron value to job creation form
- support redirect parameter when saving jobs
- expose calendar start date
- redesign calendar page with colored blocks and popup form for adding jobs

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_684f3fde6dfc8322bf52458e755a5811