### PR TITLE
Set uploaded videos to private

### DIFF
--- a/sh_scripts/configs/base.conf
+++ b/sh_scripts/configs/base.conf
@@ -42,7 +42,7 @@ TAG="lofi"
 
 # Video bilgileri
 VIDEO_CATEGORY="22"
-VIDEO_PRIVACY="unlisted"
+VIDEO_PRIVACY="private"
 THUMBNAIL_FILE="thumbnail.jpg"
 # Paths
 

--- a/sh_scripts/upload_video.sh
+++ b/sh_scripts/upload_video.sh
@@ -96,7 +96,7 @@ API_URL="https://www.googleapis.com/upload/youtube/v3/videos?uploadType=resumabl
 TITLE_ESCAPED=$(escape_json "$VIDEO_TITLE")
 DESC_ESCAPED=$(escape_json "$VIDEO_DESCRIPTION")
 [ -z "$VIDEO_CATEGORY" ] && VIDEO_CATEGORY="22"
-[ -z "$VIDEO_PRIVACY" ] && VIDEO_PRIVACY="unlisted"
+[ -z "$VIDEO_PRIVACY" ] && VIDEO_PRIVACY="private"
 JSON_DATA=$(cat <<EOF
 {
   "snippet": {


### PR DESCRIPTION
## Summary
- default privacy setting is now `private`
- changed example config to match

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6854662afb1c832298aa4be937106e77