### PR TITLE
Add live log view and responsive layout

### DIFF
--- a/src/main/java/com/youtube/ai/scheduler/JobController.java
+++ b/src/main/java/com/youtube/ai/scheduler/JobController.java
@@ -26,6 +26,7 @@ public class JobController {
         model.addAttribute("jobs", jobService.listJobs());
         model.addAttribute("scripts", jobService.listScripts());
         model.addAttribute("channels", jobService.listChannels());
+        model.addAttribute("runningIds", jobService.getRunningJobIds());
         return "list";
     }
 
@@ -64,7 +65,14 @@ public class JobController {
         Job job = jobService.get(id).orElseThrow();
         model.addAttribute("job", job);
         model.addAttribute("runs", jobRunRepository.findByJobIdOrderByRunTimeDesc(id));
+        model.addAttribute("running", jobService.isRunning(id));
         return "logs";
+    }
+
+    @GetMapping("/live/{id}")
+    @ResponseBody
+    public String liveLog(@PathVariable Long id) {
+        return jobService.getCurrentLog(id);
     }
 
     @GetMapping("/schedule")

--- a/src/main/resources/static/styles.css
+++ b/src/main/resources/static/styles.css
@@ -1,11 +1,13 @@
 body {
     font-family: Arial, sans-serif;
-    margin: 20px;
+    margin: 10px;
 }
 
 table {
     width: 100%;
     border-collapse: collapse;
+    display: block;
+    overflow-x: auto;
 }
 
 table, th, td {
@@ -21,9 +23,17 @@ th {
     background-color: #f2f2f2;
 }
 
-form input, form button {
+form {
+    display: flex;
+    flex-direction: column;
+    max-width: 600px;
+}
+
+form input, form select, form button {
     margin: 4px 0;
-    padding: 6px;
+    padding: 8px;
+    width: 100%;
+    box-sizing: border-box;
 }
 
 button {

--- a/src/main/resources/templates/calendar.html
+++ b/src/main/resources/templates/calendar.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Haftalık Takvim</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" th:href="@{/styles.css}" />
     <style>
         table.calendar { border-collapse: collapse; width: 100%; }

--- a/src/main/resources/templates/form.html
+++ b/src/main/resources/templates/form.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Yeni Görev</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" th:href="@{/styles.css}" />
 </head>
 <body>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -3,6 +3,7 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <title>SH Zamanlayıcı</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta charset="UTF-8" />
     <link rel="stylesheet" th:href="@{/styles.css}" />
 </head>

--- a/src/main/resources/templates/list.html
+++ b/src/main/resources/templates/list.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Job List</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" th:href="@{/styles.css}" />
 </head>
 <body>
@@ -12,7 +13,7 @@
 <a href="/jobs/schedule">Sıralamayı Düzenle</a> |
 <a href="/jobs/calendar">Takvim</a>
 <table>
-<tr><th>Ad</th><th>Script</th><th>Param</th><th>Cron</th><th>Durum</th><th>Son Log</th><th>İşlem</th><th>Loglar</th></tr>
+<tr><th>Ad</th><th>Script</th><th>Param</th><th>Cron</th><th>Durum</th><th>Son Log</th><th>İşlem</th><th>Loglar</th><th>Canlı</th></tr>
 <tr th:each="job : ${jobs}">
     <td th:text="${job.name}">Ad</td>
     <td th:text="${job.scriptPath}">Script</td>
@@ -25,6 +26,7 @@
         <a th:href="@{'/jobs/delete/' + ${job.id}}">Sil</a>
     </td>
     <td><a th:href="@{'/jobs/logs/' + ${job.id}}">Görüntüle</a></td>
+    <td th:text="${runningIds.contains(job.id)} ? 'Evet' : '-'">run</td>
 </tr>
 </table>
 

--- a/src/main/resources/templates/logs.html
+++ b/src/main/resources/templates/logs.html
@@ -3,10 +3,31 @@
 <head>
     <meta charset="UTF-8">
     <title>Job Logs</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" th:href="@{/styles.css}" />
 </head>
 <body>
 <h2 th:text="${job.name}">Job</h2>
+<div th:if="${running}">
+    <h3>Canlı Log</h3>
+    <pre id="liveLog" style="max-height:200px;overflow:auto;background:#000;color:#0f0;padding:5px;"></pre>
+</div>
+<script th:inline="javascript">
+/*<![CDATA[*/
+const running = [[${running}]];
+const jobId = [[${job.id}]];
+if (running) {
+    const pre = document.getElementById('liveLog');
+    function fetchLog(){
+        fetch('/jobs/live/' + jobId)
+            .then(r => r.text())
+            .then(t => pre.textContent = t);
+    }
+    fetchLog();
+    setInterval(fetchLog, 2000);
+}
+/*]]>*/
+</script>
 <table>
 <tr><th>Zaman</th><th>Exit</th><th>Log</th></tr>
 <tr th:each="run : ${runs}">

--- a/src/main/resources/templates/manual.html
+++ b/src/main/resources/templates/manual.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Manual Run</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" th:href="@{/styles.css}" />
 </head>
 <body>

--- a/src/main/resources/templates/schedule.html
+++ b/src/main/resources/templates/schedule.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Job Schedule</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" th:href="@{/styles.css}" />
     <style>
     ul { list-style-type: none; padding: 0; }


### PR DESCRIPTION
## Summary
- track running job output in memory and expose new API
- display live log while a job runs
- show running status on the job list
- update HTML templates with viewport tag for mobile
- improve stylesheet with simple responsive rules

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6855390774408322801dabd9c79ac1b3