### PR TITLE
Enhance job pages and scheduling info

### DIFF
--- a/src/main/java/com/youtube/ai/scheduler/JobController.java
+++ b/src/main/java/com/youtube/ai/scheduler/JobController.java
@@ -23,10 +23,18 @@ public class JobController {
 
     @GetMapping
     public String listJobs(Model model) {
-        model.addAttribute("jobs", jobService.listJobs());
+        java.util.List<Job> jobs = jobService.listJobs();
+        java.util.Map<Long, String> nextRuns = new java.util.HashMap<>();
+        java.time.format.DateTimeFormatter fmt = java.time.format.DateTimeFormatter.ofPattern("MM/dd HH:mm");
+        for (Job j : jobs) {
+            java.time.LocalDateTime t = jobService.getNextRunTime(j);
+            if (t != null) nextRuns.put(j.getId(), t.format(fmt));
+        }
+        model.addAttribute("jobs", jobs);
         model.addAttribute("scripts", jobService.listScripts());
         model.addAttribute("channels", jobService.listChannels());
         model.addAttribute("runningIds", jobService.getRunningJobIds());
+        model.addAttribute("nextRuns", nextRuns);
         return "list";
     }
 
@@ -35,6 +43,8 @@ public class JobController {
         Job job = new Job();
         if (cron != null) job.setCronExpression(cron);
         model.addAttribute("job", job);
+        model.addAttribute("scripts", jobService.listScripts());
+        model.addAttribute("channels", jobService.listChannels());
         return "form";
     }
 

--- a/src/main/java/com/youtube/ai/scheduler/service/JobService.java
+++ b/src/main/java/com/youtube/ai/scheduler/service/JobService.java
@@ -182,9 +182,19 @@ public class JobService {
         String[] files = dir.list((d, name) -> name.endsWith(".sh"));
         if (files == null) return Collections.emptyList();
         List<String> result = new ArrayList<>();
-        for (String f : files) result.add("sh_scripts/" + f);
+        for (String f : files) result.add(f);
         Collections.sort(result);
         return result;
+    }
+
+    public java.time.LocalDateTime getNextRunTime(Job job) {
+        try {
+            CronExpression cron = CronExpression.parse(job.getCronExpression());
+            return cron.next(java.time.LocalDateTime.now());
+        } catch (Exception e) {
+            logger.warn("Invalid cron for job {}", job.getName(), e);
+            return null;
+        }
     }
 
     public List<String> listChannels() {

--- a/src/main/resources/static/styles.css
+++ b/src/main/resources/static/styles.css
@@ -22,3 +22,16 @@ pre#liveLog {
     overflow: hidden;
     text-overflow: ellipsis;
 }
+
+.script-col {
+    max-width: 200px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+@media (max-width: 576px) {
+    .script-col {
+        max-width: 120px;
+    }
+}

--- a/src/main/resources/templates/form.html
+++ b/src/main/resources/templates/form.html
@@ -16,7 +16,11 @@
             <input type="text" th:field="*{name}" placeholder="Görev Adı" class="form-control" />
         </div>
         <div class="col-md-6">
-            <input type="text" th:field="*{scriptPath}" placeholder="Ana SH Dosyası" class="form-control" />
+            <label class="form-label w-100">Script
+                <select th:field="*{scriptPath}" class="form-select">
+                    <option th:each="s : ${scripts}" th:value="${s}" th:text="${s}"></option>
+                </select>
+            </label>
         </div>
         <div class="col-md-6">
             <input type="text" th:field="*{scriptParams}" placeholder="Script Parametreleri" class="form-control" />

--- a/src/main/resources/templates/list.html
+++ b/src/main/resources/templates/list.html
@@ -10,9 +10,9 @@
 <body>
 <div th:replace="fragments/navbar :: navbar"></div>
 <div class="container py-4">
-    <div class="d-flex justify-content-between align-items-center mb-3">
+    <div class="d-flex flex-wrap justify-content-between align-items-center mb-3">
         <h2 class="mb-0">Tanımlı Görevler</h2>
-        <div>
+        <div class="mt-2 mt-md-0">
             <a href="/jobs/new" class="btn btn-success btn-sm me-1">Yeni Görev</a>
             <a href="/jobs/schedule" class="btn btn-secondary btn-sm me-1">Sıralamayı Düzenle</a>
             <a href="/jobs/calendar" class="btn btn-info btn-sm">Takvim</a>
@@ -22,16 +22,17 @@
         <table class="table table-striped table-hover table-sm">
             <thead>
             <tr>
-                <th>Canlı</th><th>Ad</th><th>Script</th><th>Param</th><th>Cron</th><th>Durum</th><th>İşlem</th><th>Loglar</th>
+                <th>Canlı</th><th>Ad</th><th>Script</th><th>Param</th><th>Cron</th><th>Sonraki</th><th>Durum</th><th>İşlem</th><th>Loglar</th>
             </tr>
             </thead>
             <tbody>
             <tr th:each="job : ${jobs}">
                 <td th:text="${runningIds.contains(job.id)} ? 'Evet' : '-'">run</td>
                 <td th:text="${job.name}">Ad</td>
-                <td th:text="${job.scriptPath}">Script</td>
+                <td class="script-col" th:text="${job.scriptPath}">Script</td>
                 <td class="param-col" th:text="${job.scriptParams}" th:title="${job.scriptParams}">Param</td>
                 <td th:text="${job.cronExpression}">Cron</td>
+                <td th:text="${nextRuns[job.id]}">Sonraki</td>
                 <td th:text="${job.lastExitCode == null ? '-' : (job.lastExitCode == 0 ? 'Başarılı' : 'Hata')}">Durum</td>
                 <td>
                     <a th:href="@{'/jobs/run/' + ${job.id}}" class="btn btn-sm btn-primary">Çalıştır</a>


### PR DESCRIPTION
## Summary
- compute next run times in service/controller
- show next run date on job list
- make script selection dropdown for new job
- tweak mobile layout and script column styles
- return script names without `sh_scripts/` prefix

## Testing
- `./gradlew test --no-daemon`
- `./gradlew build --no-daemon` *(fails: jacoco coverage rule)*

------
https://chatgpt.com/codex/tasks/task_e_68555aa1cf808322b8f3d4474fc6892b