### PR TITLE
Add short duration sample jobs

### DIFF
--- a/src/main/resources/init.sql
+++ b/src/main/resources/init.sql
@@ -3,4 +3,6 @@ INSERT INTO job (name, script_path, script_params, channel, cron_expression, nex
   ('Daily 6h Upload', 'sh_scripts/run_pipeline_and_upload.sh', '6 --tag lofi --post-twitter', 'default', '0 0 15 * * *', NULL, NULL, true, NULL, NULL, 2),
    ('Daily 1h Upload', 'sh_scripts/run_pipeline_and_upload.sh', '1 ', 'default', '0 30 3 * * *', NULL, NULL, true, NULL, NULL, 3),
   ('Daily Tweet', 'sh_scripts/post_to_twitter.sh', '--tag lofi', 'default', '0 30 12 * * *', NULL, NULL, true, NULL, NULL, 4),
-  ('Daily Instagram Story', 'sh_scripts/post_instagram_story.sh', '', 'default', '0 0 11 * * *', NULL, NULL, true, NULL, NULL, 5);
+  ('Daily Instagram Story', 'sh_scripts/post_instagram_story.sh', '', 'default', '0 0 11 * * *', NULL, NULL, true, NULL, NULL, 5),
+  ('Example 5m Upload', 'sh_scripts/run_pipeline_and_upload.sh', '0.083 --post-twitter', 'default', NULL, NULL, NULL, true, NULL, NULL, 6),
+  ('Example 10m Stream', 'sh_scripts/run_pipeline_and_stream.sh', '0.167 --post-twitter', 'default', NULL, NULL, NULL, true, NULL, NULL, 7);


### PR DESCRIPTION
## Summary
- expand `init.sql` with example 5 minute upload job and 10 minute stream job

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6855ba7360c08322a2509ce61b7e4ec2