### PR TITLE
Add video composer story service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -280,7 +280,6 @@ bower_components
 
 # Docker
 .dockerignore
-Dockerfile
 docker-compose.yml
 docker-compose.override.yml
 .docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# Build stage
+FROM gradle:8.2.1-jdk17 AS build
+WORKDIR /workspace
+COPY . .
+RUN gradle clean build -x test
+
+# Runtime stage
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=build /workspace/build/libs/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 This project includes shell scripts for generating and uploading YouTube videos automatically. The title and description generation scripts now support using OpenAI for smarter, SEO friendly content.
 
+
+## Video Composer Service
+A new `/video-composer/story` endpoint generates story scripts based on a title and desired duration.
+It uses ChatGPT to craft a narrative and per-scene visual prompts sized to the requested length.
+Request example:
+
+```bash
+curl -X POST http://localhost:8080/video-composer/story \
+  -H 'Content-Type: application/json' \
+  -d '{"title":"Mysterious Forest","duration":"10m"}'
+```
+
+The response contains structured scenes that can be used to synthesize video and audio tracks.
+
 ## Configuration
 Shared settings live in `sh_scripts/configs/base.conf`. Example keys:
 
@@ -112,3 +126,11 @@ Add `INSTAGRAM_USERNAME` and `INSTAGRAM_PASSWORD` to your channel configuration.
 sh sh_scripts/post_instagram_story.sh
 ```
 Pipeline helper scripts accept `--post-instagram` to run this automatically after uploading or streaming.
+
+## Docker
+A Dockerfile is provided for production deployments:
+
+```bash
+docker build -t youtube-ai .
+docker run -e OPENAI_API_KEY=... -p 8080:8080 youtube-ai
+```

--- a/src/main/java/com/youtube/ai/videocomposer/VideoComposerController.java
+++ b/src/main/java/com/youtube/ai/videocomposer/VideoComposerController.java
@@ -1,0 +1,22 @@
+package com.youtube.ai.videocomposer;
+
+import com.youtube.ai.videocomposer.model.StoryRequest;
+import com.youtube.ai.videocomposer.model.StoryResponse;
+import com.youtube.ai.videocomposer.service.VideoComposerService;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/video-composer")
+public class VideoComposerController {
+
+    private final VideoComposerService service;
+
+    public VideoComposerController(VideoComposerService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/story")
+    public StoryResponse composeStory(@RequestBody StoryRequest request) {
+        return service.generateStory(request);
+    }
+}

--- a/src/main/java/com/youtube/ai/videocomposer/model/Scene.java
+++ b/src/main/java/com/youtube/ai/videocomposer/model/Scene.java
@@ -1,0 +1,43 @@
+package com.youtube.ai.videocomposer.model;
+
+/**
+ * Represents a single scene in the generated story.
+ */
+public class Scene {
+    private int index;
+    private String text;
+    private String visualPrompt;
+
+    public Scene() {
+    }
+
+    public Scene(int index, String text, String visualPrompt) {
+        this.index = index;
+        this.text = text;
+        this.visualPrompt = visualPrompt;
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    public void setIndex(int index) {
+        this.index = index;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public String getVisualPrompt() {
+        return visualPrompt;
+    }
+
+    public void setVisualPrompt(String visualPrompt) {
+        this.visualPrompt = visualPrompt;
+    }
+}

--- a/src/main/java/com/youtube/ai/videocomposer/model/StoryRequest.java
+++ b/src/main/java/com/youtube/ai/videocomposer/model/StoryRequest.java
@@ -1,0 +1,33 @@
+package com.youtube.ai.videocomposer.model;
+
+/**
+ * Request payload for story generation.
+ */
+public class StoryRequest {
+    private String title;
+    private String duration; // e.g. "10m", "1h"
+
+    public StoryRequest() {
+    }
+
+    public StoryRequest(String title, String duration) {
+        this.title = title;
+        this.duration = duration;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDuration() {
+        return duration;
+    }
+
+    public void setDuration(String duration) {
+        this.duration = duration;
+    }
+}

--- a/src/main/java/com/youtube/ai/videocomposer/model/StoryResponse.java
+++ b/src/main/java/com/youtube/ai/videocomposer/model/StoryResponse.java
@@ -1,0 +1,45 @@
+package com.youtube.ai.videocomposer.model;
+
+import java.util.List;
+
+/**
+ * Response structure for story generation.
+ */
+public class StoryResponse {
+    private String title;
+    private long durationSeconds;
+    private List<Scene> scenes;
+
+    public StoryResponse() {
+    }
+
+    public StoryResponse(String title, long durationSeconds, List<Scene> scenes) {
+        this.title = title;
+        this.durationSeconds = durationSeconds;
+        this.scenes = scenes;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public long getDurationSeconds() {
+        return durationSeconds;
+    }
+
+    public void setDurationSeconds(long durationSeconds) {
+        this.durationSeconds = durationSeconds;
+    }
+
+    public List<Scene> getScenes() {
+        return scenes;
+    }
+
+    public void setScenes(List<Scene> scenes) {
+        this.scenes = scenes;
+    }
+}

--- a/src/main/java/com/youtube/ai/videocomposer/service/VideoComposerService.java
+++ b/src/main/java/com/youtube/ai/videocomposer/service/VideoComposerService.java
@@ -1,0 +1,84 @@
+package com.youtube.ai.videocomposer.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.youtube.ai.videocomposer.model.Scene;
+import com.youtube.ai.videocomposer.model.StoryRequest;
+import com.youtube.ai.videocomposer.model.StoryResponse;
+import com.youtube.ai.videocomposer.util.DurationParser;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class VideoComposerService {
+
+    @Value("${story.words-per-second:2.0}")
+    private double wordsPerSecond;
+
+    @Value("${openai.model:gpt-4o-mini}")
+    private String model;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public StoryResponse generateStory(StoryRequest request) {
+        long duration = DurationParser.parseToSeconds(request.getDuration());
+        int targetWords = (int) Math.round(duration * wordsPerSecond);
+
+        String prompt = buildPrompt(request.getTitle(), targetWords);
+
+        Map<String, Object> body = Map.of(
+                "model", model,
+                "messages", List.of(
+                        Map.of("role", "system", "content", "You are a helpful assistant that writes video stories."),
+                        Map.of("role", "user", "content", prompt)
+                )
+        );
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        String apiKey = System.getenv("OPENAI_API_KEY");
+        if (apiKey != null) {
+            headers.setBearerAuth(apiKey);
+        }
+
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(body, headers);
+        ResponseEntity<JsonNode> response = restTemplate.postForEntity(
+                "https://api.openai.com/v1/chat/completions", entity, JsonNode.class);
+
+        String content = response.getBody()
+                .path("choices").get(0)
+                .path("message")
+                .path("content").asText();
+
+        try {
+            JsonNode node = mapper.readTree(content);
+            List<Scene> scenes = new ArrayList<>();
+            for (JsonNode sceneNode : node.path("scenes")) {
+                Scene scene = new Scene(
+                        sceneNode.path("index").asInt(),
+                        sceneNode.path("text").asText(),
+                        sceneNode.path("visual_prompt").asText()
+                );
+                scenes.add(scene);
+            }
+            return new StoryResponse(request.getTitle(), duration, scenes);
+        } catch (Exception e) {
+            // Fallback to raw content
+            Scene scene = new Scene(1, content, "");
+            return new StoryResponse(request.getTitle(), duration, List.of(scene));
+        }
+    }
+
+    private String buildPrompt(String title, int words) {
+        return "Write a story titled '" + title + "' around " + words + " words. " +
+                "Return JSON with field 'scenes', an array where each item has 'index', 'text', and 'visual_prompt'. " +
+                "Visual prompt describes the scene for a video.";
+    }
+}

--- a/src/main/java/com/youtube/ai/videocomposer/util/DurationParser.java
+++ b/src/main/java/com/youtube/ai/videocomposer/util/DurationParser.java
@@ -1,0 +1,50 @@
+package com.youtube.ai.videocomposer.util;
+
+import java.time.Duration;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Utility for parsing human readable duration strings.
+ * Supports formats like "10m", "1h", "5m30s", "600" (seconds) or "10s".
+ */
+public class DurationParser {
+
+    private static final Pattern PATTERN = Pattern.compile("(?:(\\d+)h)?(?:(\\d+)m)?(?:(\\d+)s)?");
+
+    private DurationParser() {
+        // utility
+    }
+
+    /**
+     * Parse duration string to seconds.
+     *
+     * @param input duration string
+     * @return seconds represented by the input
+     * @throws IllegalArgumentException if the input cannot be parsed
+     */
+    public static long parseToSeconds(String input) {
+        if (input == null || input.isBlank()) {
+            throw new IllegalArgumentException("Duration cannot be blank");
+        }
+        input = input.trim().toLowerCase();
+
+        // If purely numeric treat as seconds
+        if (input.matches("\\d+")) {
+            return Long.parseLong(input);
+        }
+
+        Matcher m = PATTERN.matcher(input);
+        if (m.matches()) {
+            long hours = m.group(1) != null ? Long.parseLong(m.group(1)) : 0L;
+            long minutes = m.group(2) != null ? Long.parseLong(m.group(2)) : 0L;
+            long seconds = m.group(3) != null ? Long.parseLong(m.group(3)) : 0L;
+            Duration d = Duration.ofHours(hours).plusMinutes(minutes).plusSeconds(seconds);
+            if (d.isZero()) {
+                throw new IllegalArgumentException("Duration cannot be zero");
+            }
+            return d.getSeconds();
+        }
+        throw new IllegalArgumentException("Invalid duration format: " + input);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,3 +10,7 @@ spring.jpa.defer-datasource-initialization=true
 
 spring.sql.init.mode=always
 spring.sql.init.data-locations=classpath:init.sql
+
+# Story generation defaults
+story.words-per-second=2.0
+openai.model=gpt-4o-mini

--- a/src/test/java/com/youtube/ai/videocomposer/util/DurationParserTest.java
+++ b/src/test/java/com/youtube/ai/videocomposer/util/DurationParserTest.java
@@ -1,0 +1,33 @@
+package com.youtube.ai.videocomposer.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DurationParserTest {
+
+    @Test
+    void parsesMinutes() {
+        assertEquals(600, DurationParser.parseToSeconds("10m"));
+    }
+
+    @Test
+    void parsesHours() {
+        assertEquals(3600, DurationParser.parseToSeconds("1h"));
+    }
+
+    @Test
+    void parsesSeconds() {
+        assertEquals(10, DurationParser.parseToSeconds("10s"));
+    }
+
+    @Test
+    void parsesNumeric() {
+        assertEquals(300, DurationParser.parseToSeconds("300"));
+    }
+
+    @Test
+    void invalidFormatThrows() {
+        assertThrows(IllegalArgumentException.class, () -> DurationParser.parseToSeconds("abc"));
+    }
+}


### PR DESCRIPTION
## Summary
- add video composer endpoint for ChatGPT-driven story generation
- allow configurable word pacing and OpenAI model selection
- include duration parser utility and Dockerfile

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_689e5d64c59c8322bfa7162513680714